### PR TITLE
Add EIP-4844 fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -300,6 +300,12 @@
       <scope>runtime</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+      <version>1.1.8.4</version>
+    </dependency>
+
     <!-- Hamcrest and JUnit are required dependencies of PAssert,
          which is used in the main code of DebuggingWordCount example. -->
     <dependency>

--- a/src/main/java/io/blockchainetl/ethereum/domain/Block.java
+++ b/src/main/java/io/blockchainetl/ethereum/domain/Block.java
@@ -94,6 +94,14 @@ public class Block {
     @JsonProperty("withdrawals")
     private Withdrawal[] withdrawals;
 
+    @Nullable
+    @JsonProperty("blob_gas_used")
+    private Long blobGasUsed;
+
+    @Nullable
+    @JsonProperty("excess_blob_gas")
+    private Long excessBlobGas;
+
     public Block() {}
 
     public String getType() {
@@ -260,6 +268,14 @@ public class Block {
 
     public void setWithdrawals(Withdrawal[] withdrawals) { this.withdrawals = withdrawals; }
 
+    public Long getBlobGasUsed() { return blobGasUsed; }
+
+    public void setBlobGasUsed(Long blobGasUsed) { this.blobGasUsed = blobGasUsed; }
+
+    public Long getExcessBlobGas() { return excessBlobGas; }
+
+    public void setExcessBlobGas(Long excessBlobGas) { this.excessBlobGas = excessBlobGas; }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -290,7 +306,9 @@ public class Block {
             Objects.equal(transactionCount, block.transactionCount) &&
             Objects.equal(baseFeePerGas, block.baseFeePerGas) &&
             Objects.equal(withdrawalsRoot, block.withdrawalsRoot) &&
-            Objects.equal(withdrawals, block.withdrawals);
+            Objects.equal(withdrawals, block.withdrawals) &&
+            Objects.equal(blobGasUsed, block.blobGasUsed) &&
+            Objects.equal(excessBlobGas, block.excessBlobGas);
     }
 
     @Override
@@ -298,7 +316,7 @@ public class Block {
         return Objects.hashCode(type, number, hash, parentHash, nonce, sha3Uncles, logsBloom, transactionsRoot,
             stateRoot,
             receiptsRoot, miner, difficulty, totalDifficulty, size, extraData, gasLimit, gasUsed, timestamp,
-            transactionCount, baseFeePerGas, withdrawalsRoot, withdrawals);
+            transactionCount, baseFeePerGas, withdrawalsRoot, withdrawals, blobGasUsed, excessBlobGas);
     }
 
     @Override
@@ -326,6 +344,8 @@ public class Block {
             .add("baseFeePerGas", baseFeePerGas)
             .add("withdrawalsRoot", withdrawalsRoot)
             .add("withdrawals", withdrawals)
+            .add("blobGasUsed", blobGasUsed)
+            .add("excessBlobGas", excessBlobGas)
             .toString();
     }
 }

--- a/src/main/java/io/blockchainetl/ethereum/domain/Transaction.java
+++ b/src/main/java/io/blockchainetl/ethereum/domain/Transaction.java
@@ -8,6 +8,7 @@ import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.annotate.JsonProperty;
 
 import java.math.BigInteger;
+import java.util.List;
 
 @DefaultCoder(AvroCoder.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -94,7 +95,23 @@ public class Transaction {
     @Nullable
     @JsonProperty("receipt_effective_gas_price")
     private Long receiptEffectiveGasPrice;
-    
+
+    @Nullable
+    @JsonProperty("max_fee_per_blob_gas")
+    private Long maxFeePerBlobGas;
+
+    @Nullable
+    @JsonProperty("blob_versioned_hashes")
+    private List<String> blobVersionedHashes;
+
+    @Nullable
+    @JsonProperty("receipt_blob_gas_price")
+    private Long receiptBlobGasPrice;
+
+    @Nullable
+    @JsonProperty("receipt_blob_gas_used")
+    private Long receiptBlobGasUsed;
+
     public Transaction() {}
 
     public String getType() {
@@ -257,6 +274,38 @@ public class Transaction {
 
     public void setReceiptEffectiveGasPrice(Long receiptEffectiveGasPrice) { this.receiptEffectiveGasPrice = receiptEffectiveGasPrice; }
 
+    public Long getMaxFeePerBlobGas() {
+        return maxFeePerBlobGas;
+    }
+
+    public void setMaxFeePerBlobGas(Long maxFeePerBlobGas) {
+        this.maxFeePerBlobGas = maxFeePerBlobGas;
+    }
+
+    public List<String> getBlobVersionedHashes() {
+        return blobVersionedHashes;
+    }
+
+    public void setBlobVersionedHashes(List<String> blobVersionedHashes) {
+        this.blobVersionedHashes = blobVersionedHashes;
+    }
+
+    public Long getReceiptBlobGasPrice() {
+        return receiptBlobGasPrice;
+    }
+
+    public void setReceiptBlobGasPrice(Long receiptBlobGasPrice) {
+        this.receiptBlobGasPrice = receiptBlobGasPrice;
+    }
+
+    public Long getReceiptBlobGasUsed() {
+        return receiptBlobGasUsed;
+    }
+
+    public void setReceiptBlobGasUsed(Long receiptBlobGasUsed) {
+        this.receiptBlobGasUsed = receiptBlobGasUsed;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -287,7 +336,11 @@ public class Transaction {
             Objects.equal(maxFeePerGas, that.maxFeePerGas) &&
             Objects.equal(maxPriorityFeePerGas, that.maxPriorityFeePerGas) &&
             Objects.equal(transactionType, that.transactionType) &&
-            Objects.equal(receiptEffectiveGasPrice, that.receiptEffectiveGasPrice);
+            Objects.equal(receiptEffectiveGasPrice, that.receiptEffectiveGasPrice) &&
+            Objects.equal(maxFeePerBlobGas, that.maxFeePerBlobGas) &&
+            Objects.equal(blobVersionedHashes, that.blobVersionedHashes) &&
+            Objects.equal(receiptBlobGasPrice, that.receiptBlobGasPrice) &&
+            Objects.equal(receiptBlobGasUsed, that.receiptBlobGasUsed);
     }
 
     @Override
@@ -295,7 +348,8 @@ public class Transaction {
         return Objects.hashCode(type, hash, nonce, transactionIndex, fromAddress, toAddress, value, gas, gasPrice,
             input,
             receiptCumulativeGasUsed, receiptGasUsed, receiptContractAddress, receiptRoot, receiptStatus, blockNumber,
-            blockHash, blockTimestamp, maxFeePerGas, maxPriorityFeePerGas, transactionType, receiptEffectiveGasPrice);
+            blockHash, blockTimestamp, maxFeePerGas, maxPriorityFeePerGas, transactionType, receiptEffectiveGasPrice,
+            maxFeePerBlobGas, blobVersionedHashes, receiptBlobGasPrice, receiptBlobGasUsed);
     }
 
     @Override
@@ -323,6 +377,10 @@ public class Transaction {
             .add("maxPriorityFeePerGas", maxPriorityFeePerGas)
             .add("transactionType", transactionType)
             .add("receiptEffectiveGasPrice", receiptEffectiveGasPrice)
+            .add("maxFeePerBlobGas", maxFeePerBlobGas)
+            .add("blobVersionedHashes", blobVersionedHashes)
+            .add("receiptBlobGasPrice", receiptBlobGasPrice)
+            .add("receiptBlobGasUsed", receiptBlobGasUsed)
             .toString();
     }
 }

--- a/src/main/java/io/blockchainetl/ethereum/fns/ConvertBlocksToTableRowsFn.java
+++ b/src/main/java/io/blockchainetl/ethereum/fns/ConvertBlocksToTableRowsFn.java
@@ -42,6 +42,8 @@ public class ConvertBlocksToTableRowsFn extends ConvertEntitiesToTableRowsFn {
         row.set("base_fee_per_gas", block.getBaseFeePerGas());
         row.set("withdrawals_root", block.getWithdrawalsRoot());
         row.set("withdrawals", convertWithdrawalsToTableRows(block.getWithdrawals()));
+        row.set("blob_gas_used", block.getBlobGasUsed());
+        row.set("excess_blob_gas", block.getExcessBlobGas());
     }
 
     private TableRow[] convertWithdrawalsToTableRows(Withdrawal[] withdrawals) {

--- a/src/main/java/io/blockchainetl/ethereum/fns/ConvertTransactionsToTableRowsFn.java
+++ b/src/main/java/io/blockchainetl/ethereum/fns/ConvertTransactionsToTableRowsFn.java
@@ -39,5 +39,9 @@ public class ConvertTransactionsToTableRowsFn extends ConvertEntitiesToTableRows
         row.set("max_priority_fee_per_gas", transaction.getMaxPriorityFeePerGas());
         row.set("transaction_type", transaction.getTransactionType());
         row.set("receipt_effective_gas_price", transaction.getReceiptEffectiveGasPrice());
+        row.set("max_fee_per_blob_gas", transaction.getMaxFeePerBlobGas());
+        row.set("blob_versioned_hashes", transaction.getBlobVersionedHashes());
+        row.set("receipt_blob_gas_price", transaction.getReceiptBlobGasPrice());
+        row.set("receipt_blob_gas_used", transaction.getReceiptBlobGasUsed());
     }
 }


### PR DESCRIPTION
### Description

This PR introduces new fields for EIP-4844 transactions and blocks:

- **Added New Fields**:
  - **blocks** table:
    - `blob_gas_used` (INT64): The total amount of blob gas consumed by transactions in the block.
    - `excess_blob_gas` (INT64): A running total of blob gas consumed in excess of the target, prior to the block. This is used to set blob gas pricing.
  - **transactions** table:
    - `max_fee_per_blob_gas` (INT64): The maximum fee a user is willing to pay per blob gas.
    - `blob_versioned_hashes` (STRING, REPEATED): A list of hashed outputs from kzg_to_versioned_hash.
    - `receipt_blob_gas_price` (INT64): Blob gas price in a transaction.
    - `receipt_blob_gas_used` (INT64): Blob gas used in a transaction.
